### PR TITLE
Downgrade typescript to v4.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,6 @@
         "ts-node": "^10.4.0",
         "tsconfig-paths": "^3.12.0",
         "tslib": "^2.3.1",
-        "typescript": "^4.5.4",
         "typescript-plugin-css-modules": "^3.4.0",
         "wait-on": "^6.0.1",
         "webpack": "^5.65.0",
@@ -14710,10 +14709,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-      "dev": true,
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26584,10 +26582,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-      "dev": true
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "typescript-plugin-css-modules": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "ts-node": "^10.4.0",
     "tsconfig-paths": "^3.12.0",
     "tslib": "^2.3.1",
-    "typescript": "^4.5.4",
     "typescript-plugin-css-modules": "^3.4.0",
     "wait-on": "^6.0.1",
     "webpack": "^5.65.0",


### PR DESCRIPTION
I had accidentally upgraded Typescript to v4.8 in https://github.com/OneKey-Network/OneKey-implementation/pull/252.
It turns out that on my developer PC, it crashes with an error, see https://github.com/microsoft/TypeScript/issues/49257

Going back to 4.5.5 (as it was before) solves the issue.