### PR TITLE
Client node: clean CORS declaration

### DIFF
--- a/paf-mvp-client-express/src/client-node.ts
+++ b/paf-mvp-client-express/src/client-node.ts
@@ -64,6 +64,9 @@ export class ClientNode extends Node {
   async setup(): Promise<void> {
     await super.setup();
 
+    // All endpoints support CORS pre-flight
+    this.app.expressApp.options('*', this.websiteIdentityValidator.cors);
+
     // *****************************************************************************************************************
     // ************************************************************************************************************ REST
     // *****************************************************************************************************************
@@ -94,8 +97,6 @@ export class ClientNode extends Node {
       this.endHandling
     );
 
-    this.app.expressApp.options('*', this.websiteIdentityValidator.cors);
-
     this.setEndpointConfig('GET', jsonProxyEndpoints.verify3PC, {
       endPointName: 'Verify3PC',
     });
@@ -125,8 +126,6 @@ export class ClientNode extends Node {
     this.setEndpointConfig('DELETE', jsonProxyEndpoints.delete, {
       endPointName: 'Delete',
     });
-    // enable pre-flight request for DELETE request
-    this.app.expressApp.options(jsonProxyEndpoints.delete, this.websiteIdentityValidator.cors);
     this.app.expressApp.delete(
       jsonProxyEndpoints.delete,
       this.beginHandling,
@@ -142,6 +141,7 @@ export class ClientNode extends Node {
     // *****************************************************************************************************************
     this.setEndpointConfig('GET', redirectProxyEndpoints.read, {
       endPointName: 'RedirectRead',
+      // Note this endpoint is returning a redirect operator URL, but is not redirecting (redirectResponse == false)
     });
     this.app.expressApp.get(
       redirectProxyEndpoints.read,
@@ -156,6 +156,7 @@ export class ClientNode extends Node {
 
     this.setEndpointConfig('GET', redirectProxyEndpoints.write, {
       endPointName: 'RedirectWrite',
+      // Note this endpoint is returning a redirect operator URL, but is not redirecting (redirectResponse == false)
     });
     this.app.expressApp.get(
       redirectProxyEndpoints.write,
@@ -170,6 +171,7 @@ export class ClientNode extends Node {
 
     this.setEndpointConfig('GET', redirectProxyEndpoints.delete, {
       endPointName: 'RedirectDelete',
+      // Note this endpoint is returning a redirect operator URL, but is not redirecting (redirectResponse == false)
     });
     this.app.expressApp.get(
       redirectProxyEndpoints.delete,

--- a/paf-mvp-core-js/src/express/node.ts
+++ b/paf-mvp-core-js/src/express/node.ts
@@ -40,7 +40,7 @@ export interface EndpointConfiguration {
   // Endpoint display name
   endPointName: string;
   // Whether this endpoint requires redirect return (303 + data in the query string) or not (default = not)
-  isRedirect?: boolean;
+  redirectResponse?: boolean;
   // Name of the JSON schema used to validate the request
   jsonSchemaName?: JsonSchemaType;
 }
@@ -182,7 +182,7 @@ export class Node implements INode {
   catchErrors =
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (error: unknown, req: CorrelatedRequest, res: Response, next: NextFunction) => {
-      const { endPointName, isRedirect } = this.getRequestConfig(req);
+      const { endPointName, redirectResponse } = this.getRequestConfig(req);
 
       res.locals.currentSpanStatus = SpanStatusCode.ERROR;
 
@@ -241,7 +241,7 @@ export class Node implements INode {
       this.logger.Error(errorMessage);
 
       // Now send the appropriate response
-      if (isRedirect) {
+      if (redirectResponse) {
         // Best case, we can redirect to the provided returnUrl. Worst case, we redirect to the referer
 
         // This would have been set by this.checkReturnUrl

--- a/paf-mvp-operator-express/src/operator-node.ts
+++ b/paf-mvp-operator-express/src/operator-node.ts
@@ -239,7 +239,7 @@ export class OperatorNode extends Node {
     // *****************************************************************************************************************
     this.setEndpointConfig('GET', redirectEndpoints.read, {
       endPointName: 'RedirectRead',
-      isRedirect: true,
+      redirectResponse: true,
       jsonSchemaName: JsonSchemaType.readIdAndPreferencesRedirectRequest,
     });
     this.app.expressApp.get(
@@ -257,7 +257,7 @@ export class OperatorNode extends Node {
 
     this.setEndpointConfig('GET', redirectEndpoints.write, {
       endPointName: 'RedirectWrite',
-      isRedirect: true,
+      redirectResponse: true,
       jsonSchemaName: JsonSchemaType.writeIdAndPreferencesRedirectRequest,
     });
     this.app.expressApp.get(
@@ -275,7 +275,7 @@ export class OperatorNode extends Node {
 
     this.setEndpointConfig('GET', redirectEndpoints.delete, {
       endPointName: 'RedirectDelete',
-      isRedirect: true,
+      redirectResponse: true,
       jsonSchemaName: JsonSchemaType.deleteIdAndPreferencesRedirectRequest,
     });
     this.app.expressApp.get(
@@ -458,8 +458,8 @@ export class OperatorNode extends Node {
   }
 
   checkWriteIdsAndPreferencesSignature = async (req: Request, res: Response, next: NextFunction) => {
-    const { isRedirect } = this.getRequestConfig(req);
-    const request = isRedirect
+    const { redirectResponse } = this.getRequestConfig(req);
+    const request = redirectResponse
       ? getPafDataFromQueryString<RedirectPostIdsPrefsRequest>(req)
       : getPayload<PostIdsPrefsRequest>(req);
     const validationResult = await this.validateWriteRequest(request, req);
@@ -476,9 +476,9 @@ export class OperatorNode extends Node {
   };
 
   checkDeleteIdsAndPreferencesSignature = async (req: Request, res: Response, next: NextFunction) => {
-    const { isRedirect } = this.getRequestConfig(req);
+    const { redirectResponse } = this.getRequestConfig(req);
 
-    const request = isRedirect
+    const request = redirectResponse
       ? getPafDataFromQueryString<RedirectDeleteIdsPrefsRequest>(req)
       : getPafDataFromQueryString<DeleteIdsPrefsRequest>(req);
     const requestValidationResult = await this.validateDeleteRequest(request, req);
@@ -497,8 +497,8 @@ export class OperatorNode extends Node {
   };
 
   checkReadIdsAndPreferencesSignature = async (req: Request, res: Response, next: NextFunction) => {
-    const { isRedirect } = this.getRequestConfig(req);
-    const request = isRedirect
+    const { redirectResponse } = this.getRequestConfig(req);
+    const request = redirectResponse
       ? getPafDataFromQueryString<RedirectGetIdsPrefsRequest>(req)
       : getPafDataFromQueryString<GetIdsPrefsRequest>(req);
 
@@ -566,8 +566,8 @@ export class OperatorNode extends Node {
   };
 
   checkWritePermission = (req: Request, res: Response, next: NextFunction) => {
-    const { isRedirect } = this.getRequestConfig(req);
-    const input = isRedirect
+    const { redirectResponse } = this.getRequestConfig(req);
+    const input = redirectResponse
       ? getPafDataFromQueryString<RedirectPostIdsPrefsRequest>(req)
       : getPayload<PostIdsPrefsRequest>(req);
     const request = extractRequestAndContextFromHttp<PostIdsPrefsRequest, RedirectPostIdsPrefsRequest>(
@@ -588,8 +588,8 @@ export class OperatorNode extends Node {
 
   // FIXME merge with checkWritePermission
   checkDeletePermission = (req: Request, res: Response, next: NextFunction) => {
-    const { isRedirect } = this.getRequestConfig(req);
-    const input = isRedirect
+    const { redirectResponse } = this.getRequestConfig(req);
+    const input = redirectResponse
       ? getPafDataFromQueryString<RedirectDeleteIdsPrefsRequest>(req)
       : getPafDataFromQueryString<DeleteIdsPrefsRequest>(req);
     const request = extractRequestAndContextFromHttp<DeleteIdsPrefsRequest, RedirectDeleteIdsPrefsRequest>(
@@ -684,8 +684,8 @@ export class OperatorNode extends Node {
   };
 
   checkReadPermission = (req: Request, res: Response, next: NextFunction) => {
-    const { isRedirect } = this.getRequestConfig(req);
-    const input = isRedirect
+    const { redirectResponse } = this.getRequestConfig(req);
+    const input = redirectResponse
       ? getPafDataFromQueryString<RedirectGetIdsPrefsRequest>(req)
       : getPafDataFromQueryString<GetIdsPrefsRequest>(req);
     const request = extractRequestAndContextFromHttp<GetIdsPrefsRequest, RedirectGetIdsPrefsRequest>(


### PR DESCRIPTION
And rename "isRedirect" endpoint definition to make it explicit that it triggers a redirect response (thus, client endpoints are never "redirect" endpoints)